### PR TITLE
Prepare Express app for Vercel deployment

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,34 @@
+import type { Express, Request, Response } from "express";
+import { createApp } from "../server/app";
+
+let appPromise: Promise<Express> | undefined;
+
+async function getApp(): Promise<Express> {
+  if (!appPromise) {
+    appPromise = createApp("production").then(({ app }) => app);
+  }
+
+  return appPromise;
+}
+
+export default async function handler(req: Request, res: Response) {
+  try {
+    const app = await getApp();
+
+    await new Promise<void>((resolve, reject) => {
+      app(req as any, res as any, (err?: unknown) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  } catch (error) {
+    console.error(error);
+    if (!res.headersSent) {
+      res.status(500).send("Internal Server Error");
+    }
+  }
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,68 @@
+import express, { type NextFunction, type Request, type Response, type Express } from "express";
+import { type Server } from "http";
+import { registerRoutes } from "./routes";
+import { log, serveStatic, setupVite } from "./vite";
+
+export type AppMode = "development" | "production";
+
+export interface CreateAppResult {
+  app: Express;
+  server: Server;
+}
+
+export async function createApp(mode: AppMode = (process.env.NODE_ENV === "production" ? "production" : "development")): Promise<CreateAppResult> {
+  const app = express();
+
+  app.set("env", mode);
+
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+
+  app.use((req, res, next) => {
+    const start = Date.now();
+    const path = req.path;
+    let capturedJsonResponse: Record<string, any> | undefined = undefined;
+
+    const originalResJson = res.json.bind(res);
+    res.json = ((bodyJson, ...args) => {
+      capturedJsonResponse = bodyJson;
+      return originalResJson(bodyJson, ...args);
+    }) as typeof res.json;
+
+    res.on("finish", () => {
+      const duration = Date.now() - start;
+      if (path.startsWith("/api")) {
+        let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
+        if (capturedJsonResponse) {
+          logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
+        }
+
+        if (logLine.length > 80) {
+          logLine = logLine.slice(0, 79) + "…";
+        }
+
+        log(logLine);
+      }
+    });
+
+    next();
+  });
+
+  const server = await registerRoutes(app);
+
+  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+    const status = err.status || err.statusCode || 500;
+    const message = err.message || "Internal Server Error";
+
+    res.status(status).json({ message });
+    throw err;
+  });
+
+  if (mode === "development") {
+    await setupVite(app, server);
+  } else {
+    serveStatic(app);
+  }
+
+  return { app, server };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,75 +1,25 @@
-import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
 import "dotenv/config";
+import { createApp } from "./app";
+import { log } from "./vite";
 
-const app = express();
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-
-app.use((req, res, next) => {
-  const start = Date.now();
-  const path = req.path;
-  let capturedJsonResponse: Record<string, any> | undefined = undefined;
-
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
-    capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
-  };
-
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    if (path.startsWith("/api")) {
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
-      if (capturedJsonResponse) {
-        logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
-      }
-
-      if (logLine.length > 80) {
-        logLine = logLine.slice(0, 79) + "…";
-      }
-
-      log(logLine);
-    }
-  });
-
-  next();
-});
+const mode = process.env.NODE_ENV === "production" ? "production" : "development";
 
 (async () => {
-  const server = await registerRoutes(app);
+  try {
+    const { server } = await createApp(mode);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
-
-  // importantly only setup vite in development and after
-  // setting up all the other routes so the catch-all route
-  // doesn't interfere with the other routes
-  if (app.get("env") === "development") {
-    await setupVite(app, server);
-  } else {
-    serveStatic(app);
+    const port = parseInt(process.env.PORT || "5000", 10);
+    server.listen(
+      {
+        port,
+        host: "127.0.0.1",
+      },
+      () => {
+        log(`serving on port ${port}`);
+      }
+    );
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
   }
-
-  // ALWAYS serve the app on the port specified in the environment variable PORT
-  // Other ports are firewalled. Default to 5000 if not specified.
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = parseInt(process.env.PORT || "5000", 10);
-  server.listen(
-    {
-      port,
-      host: "127.0.0.1",
-      // reusePort: true,
-    },
-    () => {
-      log(`serving on port ${port}`);
-    }
-  );
 })();

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -68,11 +68,16 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const candidatePaths = [
+    path.resolve(import.meta.dirname, "public"),
+    path.resolve(process.cwd(), "dist", "public"),
+  ];
 
-  if (!fs.existsSync(distPath)) {
+  const distPath = candidatePaths.find((candidate) => fs.existsSync(candidate));
+
+  if (!distPath) {
     throw new Error(
-      `Could not find the build directory: ${distPath}, make sure to build the client first`,
+      `Could not find the build directory. Looked in: ${candidatePaths.join(", ")}. Make sure to build the client first`,
     );
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "functions": {
+    "api/index.ts": {
+      "runtime": "nodejs20.x",
+      "includeFiles": "dist/public/**"
+    }
+  },
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/index.ts" },
+    { "source": "/(.*)", "destination": "/api/index.ts" }
+  ]
+}


### PR DESCRIPTION
## Summary
- extract a reusable Express app factory so the Node server and serverless runtime share middleware, routes, and error handling
- add a Vercel serverless entrypoint plus rewrites to serve both API routes and the built client bundle from Express
- make the static asset helper resilient to different dist locations when packaged for deployment

## Testing
- npm run build
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c85a3e66348328aa0bb2915f681732