### PR TITLE
Add version field to Vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 3,
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "functions": {


### PR DESCRIPTION
## Summary
- add the `version` property at the root of `vercel.json` so the deployment uses Vercel platform v3

## Testing
- npx vercel build *(fails: npm 403 Forbidden when fetching the Vercel CLI in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c88e11a8908328bdc1ab44f15dcd6f