### PR TITLE
Harden authentication and add deployment scripts

### DIFF
--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -98,10 +98,12 @@ export default function Login() {
           </form>
           <div className="mt-6 p-4 bg-muted rounded-lg">
             <p className="text-sm text-muted-foreground font-medium mb-2">
-              Demo Credentials:
+              Need access?
             </p>
-            <p className="text-xs text-muted-foreground">Username: admin</p>
-            <p className="text-xs text-muted-foreground">Password: Vulegbo</p>
+            <p className="text-xs text-muted-foreground">
+              Sign in with the administrator credentials configured during deployment.
+              Contact your system administrator if you need help resetting your login.
+            </p>
           </div>
         </CardContent>
       </Card>

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development DATABASE_URL=postgresql://postgres.apnktwpwfmfzceimhccp:Sultanistheman2025@aws-1-eu-north-1.pooler.supabase.com:6543/postgres tsx server/index.ts",
+    "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "db:seed": "tsx server/scripts/seed.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/replit.md
+++ b/replit.md
@@ -85,3 +85,36 @@ The application is designed to integrate with ESP32-based voting devices through
 - **REST API**: HTTP endpoints for device communication and data synchronization
 - **Device Management**: Remote device status monitoring and control capabilities
 - **Fingerprint Data**: Secure handling of biometric hash data for voter verification
+
+## Deployment Checklist
+
+To prepare the application for Vercel (or any Node.js) deployment, complete the following steps:
+
+1. **Configure environment variables**
+   - `DATABASE_URL` (required): PostgreSQL connection string with SSL support enabled.
+   - `DEFAULT_ADMIN_PASSWORD` (required for seeding): Plain-text password used when running `npm run db:seed`. This value is never stored in the repository.
+   - `DEFAULT_ADMIN_USERNAME` (optional, default `admin`): Username for the initial super admin account created by the seed script.
+   - `DEFAULT_ADMIN_FULL_NAME` (optional, default `System Administrator`): Display name for the initial admin.
+   - `SEED_SAMPLE_DATA` (optional): Set to `true` to populate demo candidates and devices during seeding.
+
+2. **Provision the database schema**
+   ```bash
+   npm run db:push
+   ```
+
+3. **Seed critical data**
+   ```bash
+   npm run db:seed
+   ```
+   This command creates the initial super admin user and, if enabled, demo data. It is safe to run multiple times; existing records will be left untouched.
+
+4. **Build the project** (Vercel runs this automatically during deployment)
+   ```bash
+   npm run build
+   ```
+   - **Build command**: `npm run build`
+   - **Output directory**: `dist`
+
+5. **Verify production readiness**
+   - Confirm that runtime environment variables are defined in Vercel.
+   - Rotate the seeded admin password after the first login and provide credentials to authorized personnel only.

--- a/server/auth/password.ts
+++ b/server/auth/password.ts
@@ -1,0 +1,64 @@
+import { randomBytes, scrypt as asyncScryptFn, scryptSync, timingSafeEqual } from "crypto";
+import { promisify } from "util";
+
+const SCRYPT_KEY_LENGTH = 64;
+const asyncScrypt = promisify(asyncScryptFn);
+
+function encodeHash(salt: Buffer, derivedKey: Buffer): string {
+  return `${salt.toString("hex")}:${derivedKey.toString("hex")}`;
+}
+
+function decodeHash(storedHash: string): { salt: Buffer; derivedKey: Buffer } | null {
+  const [saltHex, keyHex] = storedHash.split(":");
+  if (!saltHex || !keyHex) {
+    return null;
+  }
+
+  try {
+    return {
+      salt: Buffer.from(saltHex, "hex"),
+      derivedKey: Buffer.from(keyHex, "hex"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(16);
+  const derivedKey = (await asyncScrypt(password, salt, SCRYPT_KEY_LENGTH)) as Buffer;
+  return encodeHash(salt, derivedKey);
+}
+
+export function hashPasswordSync(password: string): string {
+  const salt = randomBytes(16);
+  const derivedKey = scryptSync(password, salt, SCRYPT_KEY_LENGTH);
+  return encodeHash(salt, derivedKey);
+}
+
+export async function verifyPassword(password: string, storedHash: string): Promise<boolean> {
+  const decoded = decodeHash(storedHash);
+  if (!decoded) {
+    return false;
+  }
+
+  try {
+    const derivedKey = (await asyncScrypt(password, decoded.salt, SCRYPT_KEY_LENGTH)) as Buffer;
+    if (derivedKey.length !== decoded.derivedKey.length) {
+      return false;
+    }
+
+    return timingSafeEqual(derivedKey, decoded.derivedKey);
+  } catch {
+    return false;
+  }
+}
+
+export function isPasswordHash(value: string | null | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const decoded = decodeHash(value);
+  return decoded !== null;
+}

--- a/server/db.ts
+++ b/server/db.ts
@@ -11,3 +11,7 @@ const client = postgres(process.env.DATABASE_URL, {
   prepare: false,
 });
 export const db = drizzle(client, { schema });
+
+export async function closeDb() {
+  await client.end({ timeout: 5 });
+}

--- a/server/scripts/seed.ts
+++ b/server/scripts/seed.ts
@@ -1,0 +1,94 @@
+import "dotenv/config";
+import { storage } from "../storage";
+import { hashPassword, isPasswordHash } from "../auth/password";
+import { closeDb } from "../db";
+
+function toBoolean(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+async function ensureAdminUser() {
+  const username = process.env.DEFAULT_ADMIN_USERNAME?.trim() || "admin";
+  const fullName = process.env.DEFAULT_ADMIN_FULL_NAME?.trim() || "System Administrator";
+  const passwordValue = process.env.DEFAULT_ADMIN_PASSWORD;
+
+  if (!passwordValue) {
+    throw new Error("DEFAULT_ADMIN_PASSWORD must be defined before running the seed script.");
+  }
+
+  const existingUser = await storage.getUserByUsername(username);
+  if (existingUser) {
+    if (!isPasswordHash(existingUser.password)) {
+      console.warn(`Admin user \"${username}\" exists but password is not hashed. Please reset the password manually.`);
+    }
+    console.log(`Admin user \"${username}\" already exists. Skipping creation.`);
+    return;
+  }
+
+  const password = isPasswordHash(passwordValue)
+    ? passwordValue
+    : await hashPassword(passwordValue);
+
+  await storage.createUser({
+    username,
+    password,
+    role: "super_admin",
+    fullName,
+  });
+
+  console.log(`Admin user \"${username}\" created.`);
+}
+
+async function seedSampleData() {
+  const shouldSeed = toBoolean(process.env.SEED_SAMPLE_DATA);
+  if (!shouldSeed) {
+    console.log("Sample data seeding disabled. Set SEED_SAMPLE_DATA=true to enable.");
+    return;
+  }
+
+  const candidates = await storage.getCandidates();
+  if (candidates.length === 0) {
+    await storage.createCandidate({ name: "Candidate Alpha", party: "Democratic Party", position: 1 });
+    await storage.createCandidate({ name: "Candidate Beta", party: "Republican Party", position: 2 });
+    await storage.createCandidate({ name: "Candidate Gamma", party: "Independent", position: 3 });
+    console.log("Seeded sample candidates.");
+  } else {
+    console.log("Candidates already exist. Skipping candidate seeding.");
+  }
+
+  const devices = await storage.getDevices();
+  if (devices.length === 0) {
+    await storage.createDevice({ deviceId: "machine_01", name: "Device-01", status: "online", batteryLevel: 87, location: "Building A" });
+    await storage.createDevice({ deviceId: "machine_02", name: "Device-02", status: "online", batteryLevel: 92, location: "Building B" });
+    await storage.createDevice({ deviceId: "machine_03", name: "Device-03", status: "warning", batteryLevel: 15, location: "Building C" });
+    await storage.createDevice({ deviceId: "machine_04", name: "Device-04", status: "offline", batteryLevel: 0, location: "Building D" });
+    await storage.createDevice({ deviceId: "machine_05", name: "Device-05", status: "online", batteryLevel: 76, location: "Building E" });
+    console.log("Seeded sample devices.");
+  } else {
+    console.log("Devices already exist. Skipping device seeding.");
+  }
+}
+
+async function main() {
+  try {
+    await ensureAdminUser();
+    await seedSampleData();
+    console.log("Database seed completed.");
+  } finally {
+    await closeDb();
+  }
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error("Database seed failed:", error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- replace plaintext login validation with scrypt-based hashing and audit logging
- remove startup seeding in favor of an explicit seed script driven by environment variables
- scrub hard-coded credentials from the login UI and document the deployment workflow

## Testing
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres npm run check
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca7b0f786c83289ddb1e4c00324f5a