### PR TITLE
Add authenticated sessions and protect API routes

### DIFF
--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -138,7 +138,9 @@ export default function Sidebar() {
         <Button
           variant="ghost"
           className="w-full justify-start text-muted-foreground hover:text-foreground"
-          onClick={logout}
+          onClick={() => {
+            void logout();
+          }}
           data-testid="button-logout"
         >
           <LogOut className="w-4 h-4 mr-2" />

--- a/client/src/lib/auth-events.ts
+++ b/client/src/lib/auth-events.ts
@@ -1,0 +1,11 @@
+export type UnauthorizedHandler = () => void;
+
+let unauthorizedHandler: UnauthorizedHandler | null = null;
+
+export function setUnauthorizedHandler(handler: UnauthorizedHandler | null) {
+  unauthorizedHandler = handler;
+}
+
+export function notifyUnauthorized() {
+  unauthorizedHandler?.();
+}

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,34 +1,15 @@
-import { User } from "@shared/schema";
+import type { User } from "@shared/schema";
+
+export type AuthenticatedUser = Omit<User, "password">;
 
 export interface AuthState {
-  user: User | null;
+  user: AuthenticatedUser | null;
   isAuthenticated: boolean;
 }
 
-export const getStoredUser = (): User | null => {
-  if (typeof window === "undefined") return null;
-  
-  try {
-    const stored = localStorage.getItem("auth_user");
-    return stored ? JSON.parse(stored) : null;
-  } catch {
-    return null;
-  }
-};
-
-export const setStoredUser = (user: User | null): void => {
-  if (typeof window === "undefined") return;
-  
-  if (user) {
-    localStorage.setItem("auth_user", JSON.stringify(user));
-  } else {
-    localStorage.removeItem("auth_user");
-  }
-};
-
-export const hasPermission = (user: User | null, permission: string): boolean => {
+export const hasPermission = (user: AuthenticatedUser | null, permission: string): boolean => {
   if (!user) return false;
-  
+
   const permissions = {
     super_admin: ["*"],
     election_officer: ["dashboard", "voters", "monitoring", "reports", "devices"],

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { notifyUnauthorized } from "./auth-events";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -19,6 +20,10 @@ export async function apiRequest(
     credentials: "include",
   });
 
+  if (res.status === 401) {
+    notifyUnauthorized();
+  }
+
   await throwIfResNotOk(res);
   return res;
 }
@@ -33,8 +38,12 @@ export const getQueryFn: <T>(options: {
       credentials: "include",
     });
 
-    if (unauthorizedBehavior === "returnNull" && res.status === 401) {
-      return null;
+    if (res.status === 401) {
+      notifyUnauthorized();
+
+      if (unauthorizedBehavior === "returnNull") {
+        return null;
+      }
     }
 
     await throwIfResNotOk(res);

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,5 +1,6 @@
 import express, { type NextFunction, type Request, type Response, type Express } from "express";
 import { type Server } from "http";
+import { createSessionMiddleware } from "./auth/session";
 import { registerRoutes } from "./routes";
 import { log, serveStatic, setupVite } from "./vite";
 
@@ -17,6 +18,7 @@ export async function createApp(mode: AppMode = (process.env.NODE_ENV === "produ
 
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
+  app.use(createSessionMiddleware(mode));
 
   app.use((req, res, next) => {
     const start = Date.now();

--- a/server/auth/session.ts
+++ b/server/auth/session.ts
@@ -1,0 +1,28 @@
+import session from "express-session";
+import memorystore from "memorystore";
+import type { AppMode } from "../app";
+
+const MemoryStore = memorystore(session);
+
+export const SESSION_COOKIE_NAME = "securevote.sid";
+const SESSION_MAX_AGE_MS = 1000 * 60 * 60 * 8; // 8 hours
+
+export function createSessionMiddleware(mode: AppMode) {
+  const isProduction = mode === "production";
+
+  return session({
+    secret: process.env.SESSION_SECRET ?? "securevote-dev-secret", // Override via SESSION_SECRET in production
+    resave: false,
+    saveUninitialized: false,
+    name: SESSION_COOKIE_NAME,
+    cookie: {
+      httpOnly: true,
+      sameSite: isProduction ? "strict" : "lax",
+      secure: isProduction,
+      maxAge: SESSION_MAX_AGE_MS,
+    },
+    store: new MemoryStore({
+      checkPeriod: SESSION_MAX_AGE_MS,
+    }),
+  });
+}

--- a/server/types/express-session.d.ts
+++ b/server/types/express-session.d.ts
@@ -1,0 +1,9 @@
+import "express-session";
+import type { User } from "@shared/schema";
+
+declare module "express-session" {
+  interface SessionData {
+    userId?: string;
+    user?: Omit<User, "password">;
+  }
+}


### PR DESCRIPTION
## Summary
- add Express session middleware backed by memorystore and augment session typings
- create login/session/logout flows that issue cookies and guard API endpoints with authentication middleware
- refresh the client auth provider to load server sessions, clear caches on 401 responses, and call the logout endpoint

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca82d622b08328a719e8d40df79b0b