### PR TITLE
Use shared Postgres session store

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,34 @@
+import type { Express, Request, Response } from "express";
+import { createApp } from "../server/app";
+
+let appPromise: Promise<Express> | undefined;
+
+async function getApp(): Promise<Express> {
+  if (!appPromise) {
+    appPromise = createApp("production").then(({ app }) => app);
+  }
+
+  return appPromise;
+}
+
+export default async function handler(req: Request, res: Response) {
+  try {
+    const app = await getApp();
+
+    await new Promise<void>((resolve, reject) => {
+      app(req as any, res as any, (err?: unknown) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  } catch (error) {
+    console.error(error);
+    if (!res.headersSent) {
+      res.status(500).send("Internal Server Error");
+    }
+  }
+}

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -138,7 +138,9 @@ export default function Sidebar() {
         <Button
           variant="ghost"
           className="w-full justify-start text-muted-foreground hover:text-foreground"
-          onClick={logout}
+          onClick={() => {
+            void logout();
+          }}
           data-testid="button-logout"
         >
           <LogOut className="w-4 h-4 mr-2" />

--- a/client/src/lib/auth-events.ts
+++ b/client/src/lib/auth-events.ts
@@ -1,0 +1,11 @@
+export type UnauthorizedHandler = () => void;
+
+let unauthorizedHandler: UnauthorizedHandler | null = null;
+
+export function setUnauthorizedHandler(handler: UnauthorizedHandler | null) {
+  unauthorizedHandler = handler;
+}
+
+export function notifyUnauthorized() {
+  unauthorizedHandler?.();
+}

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,34 +1,15 @@
-import { User } from "@shared/schema";
+import type { User } from "@shared/schema";
+
+export type AuthenticatedUser = Omit<User, "password">;
 
 export interface AuthState {
-  user: User | null;
+  user: AuthenticatedUser | null;
   isAuthenticated: boolean;
 }
 
-export const getStoredUser = (): User | null => {
-  if (typeof window === "undefined") return null;
-  
-  try {
-    const stored = localStorage.getItem("auth_user");
-    return stored ? JSON.parse(stored) : null;
-  } catch {
-    return null;
-  }
-};
-
-export const setStoredUser = (user: User | null): void => {
-  if (typeof window === "undefined") return;
-  
-  if (user) {
-    localStorage.setItem("auth_user", JSON.stringify(user));
-  } else {
-    localStorage.removeItem("auth_user");
-  }
-};
-
-export const hasPermission = (user: User | null, permission: string): boolean => {
+export const hasPermission = (user: AuthenticatedUser | null, permission: string): boolean => {
   if (!user) return false;
-  
+
   const permissions = {
     super_admin: ["*"],
     election_officer: ["dashboard", "voters", "monitoring", "reports", "devices"],

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { notifyUnauthorized } from "./auth-events";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -19,6 +20,10 @@ export async function apiRequest(
     credentials: "include",
   });
 
+  if (res.status === 401) {
+    notifyUnauthorized();
+  }
+
   await throwIfResNotOk(res);
   return res;
 }
@@ -33,8 +38,12 @@ export const getQueryFn: <T>(options: {
       credentials: "include",
     });
 
-    if (unauthorizedBehavior === "returnNull" && res.status === 401) {
-      return null;
+    if (res.status === 401) {
+      notifyUnauthorized();
+
+      if (unauthorizedBehavior === "returnNull") {
+        return null;
+      }
     }
 
     await throwIfResNotOk(res);

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -98,10 +98,12 @@ export default function Login() {
           </form>
           <div className="mt-6 p-4 bg-muted rounded-lg">
             <p className="text-sm text-muted-foreground font-medium mb-2">
-              Demo Credentials:
+              Need access?
             </p>
-            <p className="text-xs text-muted-foreground">Username: admin</p>
-            <p className="text-xs text-muted-foreground">Password: Vulegbo</p>
+            <p className="text-xs text-muted-foreground">
+              Sign in with the administrator credentials configured during deployment.
+              Contact your system administrator if you need help resetting your login.
+            </p>
           </div>
         </CardContent>
       </Card>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "@neondatabase/serverless": "^0.10.4",
         "@radix-ui/react-accordion": "^1.2.4",
         "@radix-ui/react-alert-dialog": "^1.1.7",
         "@radix-ui/react-aspect-ratio": "^1.1.3",
@@ -54,10 +53,10 @@
         "framer-motion": "^11.13.1",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.453.0",
-        "memorystore": "^1.6.7",
         "next-themes": "^0.4.6",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
+        "pg": "^8.13.1",
         "postgres": "^3.4.7",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
@@ -1396,6 +1395,8 @@
       "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.10.4.tgz",
       "integrity": "sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/pg": "8.11.6"
       }
@@ -3492,6 +3493,7 @@
       "version": "20.16.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
       "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -3534,6 +3536,7 @@
       "version": "8.11.6",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
       "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -4280,6 +4283,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6098,35 +6102,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/memorystore": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/memorystore/-/memorystore-1.6.7.tgz",
-      "integrity": "sha512-OZnmNY/NDrKohPQ+hxp0muBcBKrzKNtHr55DbqSx9hLsYVNnomSAMRAtI7R64t3gf3ID7tHQA7mG4oL3Hu9hdw==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.0",
-        "lru-cache": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/memorystore/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/memorystore/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "license": "ISC"
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -6370,6 +6345,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -6546,6 +6522,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
       "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=4"
@@ -6570,6 +6547,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
       "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -6844,6 +6822,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
       "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6853,6 +6832,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
       "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "obuf": "~1.1.2"
@@ -6865,6 +6845,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
       "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6874,6 +6855,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
       "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6883,6 +6865,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/prop-types": {
@@ -6912,12 +6895,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "license": "ISC"
     },
     "node_modules/qs": {
       "version": "6.13.0",
@@ -8334,6 +8311,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development DATABASE_URL=postgresql://postgres.apnktwpwfmfzceimhccp:Sultanistheman2025@aws-1-eu-north-1.pooler.supabase.com:6543/postgres tsx server/index.ts",
+    "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "db:seed": "tsx server/scripts/seed.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "framer-motion": "^11.13.1",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.453.0",
-    "memorystore": "^1.6.7",
+    "pg": "^8.13.1",
     "next-themes": "^0.4.6",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",

--- a/replit.md
+++ b/replit.md
@@ -92,6 +92,11 @@ To prepare the application for Vercel (or any Node.js) deployment, complete the 
 
 1. **Configure environment variables**
    - `DATABASE_URL` (required): PostgreSQL connection string with SSL support enabled.
+   - `SESSION_STORE_URL` (optional): PostgreSQL connection string dedicated to session storage. Defaults to `DATABASE_URL`.
+   - `SESSION_STORE_SSLMODE` (optional): Controls TLS verification for the session store connection (`require`, `verify-full`, or `disable`). Defaults to `require`.
+   - `SESSION_STORE_SCHEMA` (optional): Custom schema for the session table when different from `public`.
+   - `SESSION_STORE_TABLE` (optional): Override the session table name (default `session`).
+   - `SESSION_STORE_CREATE_TABLE` (optional): Set to `false` to disable automatic session table creation.
    - `DEFAULT_ADMIN_PASSWORD` (required for seeding): Plain-text password used when running `npm run db:seed`. This value is never stored in the repository.
    - `DEFAULT_ADMIN_USERNAME` (optional, default `admin`): Username for the initial super admin account created by the seed script.
    - `DEFAULT_ADMIN_FULL_NAME` (optional, default `System Administrator`): Display name for the initial admin.

--- a/replit.md
+++ b/replit.md
@@ -85,3 +85,36 @@ The application is designed to integrate with ESP32-based voting devices through
 - **REST API**: HTTP endpoints for device communication and data synchronization
 - **Device Management**: Remote device status monitoring and control capabilities
 - **Fingerprint Data**: Secure handling of biometric hash data for voter verification
+
+## Deployment Checklist
+
+To prepare the application for Vercel (or any Node.js) deployment, complete the following steps:
+
+1. **Configure environment variables**
+   - `DATABASE_URL` (required): PostgreSQL connection string with SSL support enabled.
+   - `DEFAULT_ADMIN_PASSWORD` (required for seeding): Plain-text password used when running `npm run db:seed`. This value is never stored in the repository.
+   - `DEFAULT_ADMIN_USERNAME` (optional, default `admin`): Username for the initial super admin account created by the seed script.
+   - `DEFAULT_ADMIN_FULL_NAME` (optional, default `System Administrator`): Display name for the initial admin.
+   - `SEED_SAMPLE_DATA` (optional): Set to `true` to populate demo candidates and devices during seeding.
+
+2. **Provision the database schema**
+   ```bash
+   npm run db:push
+   ```
+
+3. **Seed critical data**
+   ```bash
+   npm run db:seed
+   ```
+   This command creates the initial super admin user and, if enabled, demo data. It is safe to run multiple times; existing records will be left untouched.
+
+4. **Build the project** (Vercel runs this automatically during deployment)
+   ```bash
+   npm run build
+   ```
+   - **Build command**: `npm run build`
+   - **Output directory**: `dist`
+
+5. **Verify production readiness**
+   - Confirm that runtime environment variables are defined in Vercel.
+   - Rotate the seeded admin password after the first login and provide credentials to authorized personnel only.

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,68 @@
+import express, { type NextFunction, type Request, type Response, type Express } from "express";
+import { type Server } from "http";
+import { registerRoutes } from "./routes";
+import { log, serveStatic, setupVite } from "./vite";
+
+export type AppMode = "development" | "production";
+
+export interface CreateAppResult {
+  app: Express;
+  server: Server;
+}
+
+export async function createApp(mode: AppMode = (process.env.NODE_ENV === "production" ? "production" : "development")): Promise<CreateAppResult> {
+  const app = express();
+
+  app.set("env", mode);
+
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+
+  app.use((req, res, next) => {
+    const start = Date.now();
+    const path = req.path;
+    let capturedJsonResponse: Record<string, any> | undefined = undefined;
+
+    const originalResJson = res.json.bind(res);
+    res.json = ((bodyJson, ...args) => {
+      capturedJsonResponse = bodyJson;
+      return originalResJson(bodyJson, ...args);
+    }) as typeof res.json;
+
+    res.on("finish", () => {
+      const duration = Date.now() - start;
+      if (path.startsWith("/api")) {
+        let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
+        if (capturedJsonResponse) {
+          logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
+        }
+
+        if (logLine.length > 80) {
+          logLine = logLine.slice(0, 79) + "…";
+        }
+
+        log(logLine);
+      }
+    });
+
+    next();
+  });
+
+  const server = await registerRoutes(app);
+
+  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+    const status = err.status || err.statusCode || 500;
+    const message = err.message || "Internal Server Error";
+
+    res.status(status).json({ message });
+    throw err;
+  });
+
+  if (mode === "development") {
+    await setupVite(app, server);
+  } else {
+    serveStatic(app);
+  }
+
+  return { app, server };
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,5 +1,6 @@
 import express, { type NextFunction, type Request, type Response, type Express } from "express";
 import { type Server } from "http";
+import { createSessionMiddleware } from "./auth/session";
 import { registerRoutes } from "./routes";
 import { log, serveStatic, setupVite } from "./vite";
 
@@ -17,6 +18,7 @@ export async function createApp(mode: AppMode = (process.env.NODE_ENV === "produ
 
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
+  app.use(createSessionMiddleware(mode));
 
   app.use((req, res, next) => {
     const start = Date.now();

--- a/server/auth/password.ts
+++ b/server/auth/password.ts
@@ -1,0 +1,64 @@
+import { randomBytes, scrypt as asyncScryptFn, scryptSync, timingSafeEqual } from "crypto";
+import { promisify } from "util";
+
+const SCRYPT_KEY_LENGTH = 64;
+const asyncScrypt = promisify(asyncScryptFn);
+
+function encodeHash(salt: Buffer, derivedKey: Buffer): string {
+  return `${salt.toString("hex")}:${derivedKey.toString("hex")}`;
+}
+
+function decodeHash(storedHash: string): { salt: Buffer; derivedKey: Buffer } | null {
+  const [saltHex, keyHex] = storedHash.split(":");
+  if (!saltHex || !keyHex) {
+    return null;
+  }
+
+  try {
+    return {
+      salt: Buffer.from(saltHex, "hex"),
+      derivedKey: Buffer.from(keyHex, "hex"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(16);
+  const derivedKey = (await asyncScrypt(password, salt, SCRYPT_KEY_LENGTH)) as Buffer;
+  return encodeHash(salt, derivedKey);
+}
+
+export function hashPasswordSync(password: string): string {
+  const salt = randomBytes(16);
+  const derivedKey = scryptSync(password, salt, SCRYPT_KEY_LENGTH);
+  return encodeHash(salt, derivedKey);
+}
+
+export async function verifyPassword(password: string, storedHash: string): Promise<boolean> {
+  const decoded = decodeHash(storedHash);
+  if (!decoded) {
+    return false;
+  }
+
+  try {
+    const derivedKey = (await asyncScrypt(password, decoded.salt, SCRYPT_KEY_LENGTH)) as Buffer;
+    if (derivedKey.length !== decoded.derivedKey.length) {
+      return false;
+    }
+
+    return timingSafeEqual(derivedKey, decoded.derivedKey);
+  } catch {
+    return false;
+  }
+}
+
+export function isPasswordHash(value: string | null | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const decoded = decodeHash(value);
+  return decoded !== null;
+}

--- a/server/auth/session.ts
+++ b/server/auth/session.ts
@@ -1,0 +1,28 @@
+import session from "express-session";
+import memorystore from "memorystore";
+import type { AppMode } from "../app";
+
+const MemoryStore = memorystore(session);
+
+export const SESSION_COOKIE_NAME = "securevote.sid";
+const SESSION_MAX_AGE_MS = 1000 * 60 * 60 * 8; // 8 hours
+
+export function createSessionMiddleware(mode: AppMode) {
+  const isProduction = mode === "production";
+
+  return session({
+    secret: process.env.SESSION_SECRET ?? "securevote-dev-secret", // Override via SESSION_SECRET in production
+    resave: false,
+    saveUninitialized: false,
+    name: SESSION_COOKIE_NAME,
+    cookie: {
+      httpOnly: true,
+      sameSite: isProduction ? "strict" : "lax",
+      secure: isProduction,
+      maxAge: SESSION_MAX_AGE_MS,
+    },
+    store: new MemoryStore({
+      checkPeriod: SESSION_MAX_AGE_MS,
+    }),
+  });
+}

--- a/server/auth/session.ts
+++ b/server/auth/session.ts
@@ -1,11 +1,81 @@
 import session from "express-session";
-import memorystore from "memorystore";
+import connectPgSimple from "connect-pg-simple";
+import type { PoolConfig } from "pg";
 import type { AppMode } from "../app";
-
-const MemoryStore = memorystore(session);
 
 export const SESSION_COOKIE_NAME = "securevote.sid";
 const SESSION_MAX_AGE_MS = 1000 * 60 * 60 * 8; // 8 hours
+
+const PgSessionStore = connectPgSimple(session);
+
+let sessionStore: InstanceType<typeof PgSessionStore> | null = null;
+
+function resolveSessionStore() {
+  if (sessionStore) {
+    return sessionStore;
+  }
+
+  const connectionString =
+    process.env.SESSION_STORE_URL ?? process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    throw new Error(
+      "SESSION_STORE_URL or DATABASE_URL must be defined to configure the session store.",
+    );
+  }
+
+  const sslMode = (process.env.SESSION_STORE_SSLMODE ?? "require").toLowerCase();
+
+  let ssl: PoolConfig["ssl"];
+  switch (sslMode) {
+    case "disable":
+    case "false":
+    case "off":
+      ssl = undefined;
+      break;
+    case "verify-full":
+    case "true":
+    case "strict":
+      ssl = { rejectUnauthorized: true };
+      break;
+    default:
+      ssl = { rejectUnauthorized: false };
+      break;
+  }
+
+  const ttlSeconds = Math.floor(SESSION_MAX_AGE_MS / 1000);
+  const shouldCreateTable =
+    (process.env.SESSION_STORE_CREATE_TABLE ?? "true").toLowerCase() !== "false";
+  const tableName = process.env.SESSION_STORE_TABLE ?? "session";
+  const schemaName = process.env.SESSION_STORE_SCHEMA;
+
+  const storeOptions: connectPgSimple.PGStoreOptions = {
+    createTableIfMissing: shouldCreateTable,
+    tableName,
+    schemaName,
+    ttl: ttlSeconds,
+    conObject: buildPoolConfig(connectionString, ssl),
+  };
+
+  sessionStore = new PgSessionStore(storeOptions);
+
+  return sessionStore;
+}
+
+function buildPoolConfig(
+  connectionString: string,
+  ssl: PoolConfig["ssl"],
+): PoolConfig {
+  const poolConfig: PoolConfig = {
+    connectionString,
+  };
+
+  if (ssl !== undefined) {
+    poolConfig.ssl = ssl;
+  }
+
+  return poolConfig;
+}
 
 export function createSessionMiddleware(mode: AppMode) {
   const isProduction = mode === "production";
@@ -21,8 +91,6 @@ export function createSessionMiddleware(mode: AppMode) {
       secure: isProduction,
       maxAge: SESSION_MAX_AGE_MS,
     },
-    store: new MemoryStore({
-      checkPeriod: SESSION_MAX_AGE_MS,
-    }),
+    store: resolveSessionStore(),
   });
 }

--- a/server/db.ts
+++ b/server/db.ts
@@ -11,3 +11,7 @@ const client = postgres(process.env.DATABASE_URL, {
   prepare: false,
 });
 export const db = drizzle(client, { schema });
+
+export async function closeDb() {
+  await client.end({ timeout: 5 });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,75 +1,25 @@
-import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
 import "dotenv/config";
+import { createApp } from "./app";
+import { log } from "./vite";
 
-const app = express();
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-
-app.use((req, res, next) => {
-  const start = Date.now();
-  const path = req.path;
-  let capturedJsonResponse: Record<string, any> | undefined = undefined;
-
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
-    capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
-  };
-
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    if (path.startsWith("/api")) {
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
-      if (capturedJsonResponse) {
-        logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
-      }
-
-      if (logLine.length > 80) {
-        logLine = logLine.slice(0, 79) + "…";
-      }
-
-      log(logLine);
-    }
-  });
-
-  next();
-});
+const mode = process.env.NODE_ENV === "production" ? "production" : "development";
 
 (async () => {
-  const server = await registerRoutes(app);
+  try {
+    const { server } = await createApp(mode);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
-
-  // importantly only setup vite in development and after
-  // setting up all the other routes so the catch-all route
-  // doesn't interfere with the other routes
-  if (app.get("env") === "development") {
-    await setupVite(app, server);
-  } else {
-    serveStatic(app);
+    const port = parseInt(process.env.PORT || "5000", 10);
+    server.listen(
+      {
+        port,
+        host: "127.0.0.1",
+      },
+      () => {
+        log(`serving on port ${port}`);
+      }
+    );
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
   }
-
-  // ALWAYS serve the app on the port specified in the environment variable PORT
-  // Other ports are firewalled. Default to 5000 if not specified.
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = parseInt(process.env.PORT || "5000", 10);
-  server.listen(
-    {
-      port,
-      host: "127.0.0.1",
-      // reusePort: true,
-    },
-    () => {
-      log(`serving on port ${port}`);
-    }
-  );
 })();

--- a/server/scripts/seed.ts
+++ b/server/scripts/seed.ts
@@ -1,0 +1,94 @@
+import "dotenv/config";
+import { storage } from "../storage";
+import { hashPassword, isPasswordHash } from "../auth/password";
+import { closeDb } from "../db";
+
+function toBoolean(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+async function ensureAdminUser() {
+  const username = process.env.DEFAULT_ADMIN_USERNAME?.trim() || "admin";
+  const fullName = process.env.DEFAULT_ADMIN_FULL_NAME?.trim() || "System Administrator";
+  const passwordValue = process.env.DEFAULT_ADMIN_PASSWORD;
+
+  if (!passwordValue) {
+    throw new Error("DEFAULT_ADMIN_PASSWORD must be defined before running the seed script.");
+  }
+
+  const existingUser = await storage.getUserByUsername(username);
+  if (existingUser) {
+    if (!isPasswordHash(existingUser.password)) {
+      console.warn(`Admin user \"${username}\" exists but password is not hashed. Please reset the password manually.`);
+    }
+    console.log(`Admin user \"${username}\" already exists. Skipping creation.`);
+    return;
+  }
+
+  const password = isPasswordHash(passwordValue)
+    ? passwordValue
+    : await hashPassword(passwordValue);
+
+  await storage.createUser({
+    username,
+    password,
+    role: "super_admin",
+    fullName,
+  });
+
+  console.log(`Admin user \"${username}\" created.`);
+}
+
+async function seedSampleData() {
+  const shouldSeed = toBoolean(process.env.SEED_SAMPLE_DATA);
+  if (!shouldSeed) {
+    console.log("Sample data seeding disabled. Set SEED_SAMPLE_DATA=true to enable.");
+    return;
+  }
+
+  const candidates = await storage.getCandidates();
+  if (candidates.length === 0) {
+    await storage.createCandidate({ name: "Candidate Alpha", party: "Democratic Party", position: 1 });
+    await storage.createCandidate({ name: "Candidate Beta", party: "Republican Party", position: 2 });
+    await storage.createCandidate({ name: "Candidate Gamma", party: "Independent", position: 3 });
+    console.log("Seeded sample candidates.");
+  } else {
+    console.log("Candidates already exist. Skipping candidate seeding.");
+  }
+
+  const devices = await storage.getDevices();
+  if (devices.length === 0) {
+    await storage.createDevice({ deviceId: "machine_01", name: "Device-01", status: "online", batteryLevel: 87, location: "Building A" });
+    await storage.createDevice({ deviceId: "machine_02", name: "Device-02", status: "online", batteryLevel: 92, location: "Building B" });
+    await storage.createDevice({ deviceId: "machine_03", name: "Device-03", status: "warning", batteryLevel: 15, location: "Building C" });
+    await storage.createDevice({ deviceId: "machine_04", name: "Device-04", status: "offline", batteryLevel: 0, location: "Building D" });
+    await storage.createDevice({ deviceId: "machine_05", name: "Device-05", status: "online", batteryLevel: 76, location: "Building E" });
+    console.log("Seeded sample devices.");
+  } else {
+    console.log("Devices already exist. Skipping device seeding.");
+  }
+}
+
+async function main() {
+  try {
+    await ensureAdminUser();
+    await seedSampleData();
+    console.log("Database seed completed.");
+  } finally {
+    await closeDb();
+  }
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error("Database seed failed:", error);
+    process.exit(1);
+  });

--- a/server/types/express-session.d.ts
+++ b/server/types/express-session.d.ts
@@ -1,0 +1,9 @@
+import "express-session";
+import type { User } from "@shared/schema";
+
+declare module "express-session" {
+  interface SessionData {
+    userId?: string;
+    user?: Omit<User, "password">;
+  }
+}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -68,11 +68,16 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const candidatePaths = [
+    path.resolve(import.meta.dirname, "public"),
+    path.resolve(process.cwd(), "dist", "public"),
+  ];
 
-  if (!fs.existsSync(distPath)) {
+  const distPath = candidatePaths.find((candidate) => fs.existsSync(candidate));
+
+  if (!distPath) {
     throw new Error(
-      `Could not find the build directory: ${distPath}, make sure to build the client first`,
+      `Could not find the build directory. Looked in: ${candidatePaths.join(", ")}. Make sure to build the client first`,
     );
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 3,
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "functions": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "functions": {
+    "api/index.ts": {
+      "runtime": "nodejs20.x",
+      "includeFiles": "dist/public/**"
+    }
+  },
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/index.ts" },
+    { "source": "/(.*)", "destination": "/api/index.ts" }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the in-memory session store with a shared PostgreSQL-backed store using `connect-pg-simple`
- allow the session store connection, schema, and lifecycle to be configured through environment variables while initializing the store only once per instance
- document the new environment variables required for configuring the shared session store

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca92d2e5a48328bccfa8dd88877e35