### PR TITLE
Enforce production session secret configuration

### DIFF
--- a/replit.md
+++ b/replit.md
@@ -92,6 +92,7 @@ To prepare the application for Vercel (or any Node.js) deployment, complete the 
 
 1. **Configure environment variables**
    - `DATABASE_URL` (required): PostgreSQL connection string with SSL support enabled.
+   - `SESSION_SECRET` (required in production): At least 32 random characters. Generate a unique, high-entropy value (for example with `openssl rand -hex 32`) and store it as a protected environment secret.
    - `DEFAULT_ADMIN_PASSWORD` (required for seeding): Plain-text password used when running `npm run db:seed`. This value is never stored in the repository.
    - `DEFAULT_ADMIN_USERNAME` (optional, default `admin`): Username for the initial super admin account created by the seed script.
    - `DEFAULT_ADMIN_FULL_NAME` (optional, default `System Administrator`): Display name for the initial admin.
@@ -117,4 +118,5 @@ To prepare the application for Vercel (or any Node.js) deployment, complete the 
 
 5. **Verify production readiness**
    - Confirm that runtime environment variables are defined in Vercel.
+   - Create a Vercel secret named `securevote-session-secret` containing your generated `SESSION_SECRET`, then link it to the project (the deployment configuration references this secret automatically).
    - Rotate the seeded admin password after the first login and provide credentials to authorized personnel only.

--- a/server/auth/session.ts
+++ b/server/auth/session.ts
@@ -6,12 +6,29 @@ const MemoryStore = memorystore(session);
 
 export const SESSION_COOKIE_NAME = "securevote.sid";
 const SESSION_MAX_AGE_MS = 1000 * 60 * 60 * 8; // 8 hours
+const SESSION_SECRET_MIN_LENGTH = 32;
 
 export function createSessionMiddleware(mode: AppMode) {
   const isProduction = mode === "production";
+  const rawSessionSecret = process.env.SESSION_SECRET;
+  const normalizedSessionSecret = rawSessionSecret?.trim();
+
+  if (isProduction) {
+    if (!normalizedSessionSecret) {
+      throw new Error(
+        "SESSION_SECRET environment variable must be provided in production."
+      );
+    }
+
+    if (normalizedSessionSecret.length < SESSION_SECRET_MIN_LENGTH) {
+      throw new Error(
+        `SESSION_SECRET must be at least ${SESSION_SECRET_MIN_LENGTH} characters long to provide sufficient entropy.`
+      );
+    }
+  }
 
   return session({
-    secret: process.env.SESSION_SECRET ?? "securevote-dev-secret", // Override via SESSION_SECRET in production
+    secret: rawSessionSecret ?? "securevote-dev-secret", // Override via SESSION_SECRET in production
     resave: false,
     saveUninitialized: false,
     name: SESSION_COOKIE_NAME,

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,9 @@
       "includeFiles": "dist/public/**"
     }
   },
+  "env": {
+    "SESSION_SECRET": "@securevote-session-secret"
+  },
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/index.ts" },
     { "source": "/(.*)", "destination": "/api/index.ts" }


### PR DESCRIPTION
## Summary
- require a production `SESSION_SECRET` and enforce a 32+ character minimum before mounting the session middleware
- document the secret requirement and instruct deployments to provision a protected Vercel secret for it
- reference the Vercel secret from the deployment configuration so pipelines must supply the value

## Testing
- `npm run check`
- `NODE_PATH=/workspace/SecureVote/node_modules SESSION_SECRET="$(openssl rand -hex 32)" npx tsx /tmp/auth-smoke.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ca92cb3f1c832893a713e79902d148