### PR TITLE
Fix Vercel session secret configuration

### DIFF
--- a/replit.md
+++ b/replit.md
@@ -118,5 +118,5 @@ To prepare the application for Vercel (or any Node.js) deployment, complete the 
 
 5. **Verify production readiness**
    - Confirm that runtime environment variables are defined in Vercel.
-   - Create a Vercel secret named `securevote-session-secret` containing your generated `SESSION_SECRET`, then link it to the project (the deployment configuration references this secret automatically).
+   - In your Vercel project settings, add an Environment Variable named `SESSION_SECRET` with the value you generated earlier (minimum 32 random characters). If you prefer using the Vercel CLI, run `vercel env add SESSION_SECRET production` and paste the secret value when prompted.
    - Rotate the seeded admin password after the first login and provide credentials to authorized personnel only.

--- a/vercel.json
+++ b/vercel.json
@@ -8,9 +8,6 @@
       "includeFiles": "dist/public/**"
     }
   },
-  "env": {
-    "SESSION_SECRET": "@securevote-session-secret"
-  },
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/index.ts" },
     { "source": "/(.*)", "destination": "/api/index.ts" }


### PR DESCRIPTION
## Summary
- remove the hard-coded Vercel secret reference so deployments rely on a user-provided SESSION_SECRET environment variable
- update the deployment checklist to explain how to add the SESSION_SECRET via Vercel settings or CLI

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca9f55f8cc832882a086813d774978