### PR TITLE
Fix Vercel runtime configuration

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,6 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
@@ -41,12 +42,14 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
+  const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;
 
     try {
       const clientTemplate = path.resolve(
-        import.meta.dirname,
+        currentDir,
         "..",
         "client",
         "index.html",
@@ -68,8 +71,10 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
+  const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
   const candidatePaths = [
-    path.resolve(import.meta.dirname, "public"),
+    path.resolve(currentDir, "public"),
     path.resolve(process.cwd(), "dist", "public"),
   ];
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "outputDirectory": "dist",
   "functions": {
     "api/index.ts": {
-      "runtime": "nodejs20.x",
+      "runtime": "nodejs18.x",
       "includeFiles": "dist/public/**"
     }
   },


### PR DESCRIPTION
## Summary
- update the server-side Vite helper to resolve file system paths via `fileURLToPath`, removing the dependency on Node 20 specific `import.meta.dirname`
- configure the deployed function to run on the Vercel-supported Node.js 18 runtime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab74ae1148328addb392c267ab712