### PR TITLE
Specify Vercel Node runtime version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "outputDirectory": "dist",
   "functions": {
     "api/index.ts": {
-      "runtime": "nodejs18.x",
+      "runtime": "@vercel/node@4.0.0",
       "includeFiles": "dist/public/**"
     }
   },


### PR DESCRIPTION
## Summary
- update the Vercel function configuration to use the explicit @vercel/node@4.0.0 runtime identifier

## Testing
- not run (Vercel deployment requires project credentials)

------
https://chatgpt.com/codex/tasks/task_e_68cac276b958832891f663dfcda6c91c